### PR TITLE
Add `top` to list of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Lore funcionality is split into a set of subcommands:
 
  - `add`
  - `new`
+ - `top`
  - `dump`
  - `search`
  - `import`


### PR DESCRIPTION
Missing from main list of commands. Minor change.
