### PR TITLE
Add update/delete commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ This writes the lore to the `output_file`. Suitable for serving via the web, if 
 
 `loredb.py update timestamp author lore`
 
-This will update the author and/or lore of a single piece of lore matching `timestamp`.
+This will update the author and/or lore of a single piece of lore with time
+matching `timestamp`.
 
 `loredb.py delete timestamp`
 
-This will delete a single piece of lore matching `timestamp`.
+This will delete a single piece of lore with time matching `timestamp`.
 
 Both `update` and `delete` will exit with an error if there is either no lore
 matching `timestamp` or more than one piece of lore that matches.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Lore funcionality is split into a set of subcommands:
  - `search`
  - `import`
  - `random`
+ - `update`
+ - `delete`
 
 ## Adding lore
 
@@ -64,3 +66,15 @@ This will search the lore for `pattern`. `-a` specifies you want to search by th
 
 This writes the lore to the `output_file`. Suitable for serving via the web, if desired.
 
+## Updating and deleting lore
+
+`loredb.py update timestamp author lore`
+
+This will update the author and/or lore of a single piece of lore matching `timestamp`.
+
+`loredb.py delete timestamp`
+
+This will delete a single piece of lore matching `timestamp`.
+
+Both `update` and `delete` will exit with an error if there is either no lore
+matching `timestamp` or more than one piece of lore that matches.

--- a/loredb.py
+++ b/loredb.py
@@ -185,17 +185,6 @@ def top(num=10):
         print(lore.author.ljust(col_size), '\t', lore.count)
 
 
-# def _num_lores(timestamp):
-#     lore = Lore.select(Lore.time == timestamp)
-#     matches = lore.count()
-#     if matches == 0:
-#         raise RuntimeError("No lore with timestamp")
-#     elif matches > 1:
-#         raise RuntimeError("Multiple pieces of lore matched timestmap")
-#     else:
-#         return lore
-
-
 def delete(timestamp):
     try:
         t = datetime_parser.parse(timestamp)

--- a/loredb.py
+++ b/loredb.py
@@ -9,7 +9,7 @@ import argparse
 import datetime
 import csv
 import sys
-from dateutil import parser
+from dateutil import parser as datetime_parser
 import peewee
 
 
@@ -66,6 +66,15 @@ def main():
     top_parser = subparsers.add_parser("top")
     top_parser.add_argument('-n', '--num', help='limit number of loremasters',
                             type=int, default=10)
+
+    delete_parser = subparsers.add_parser("delete")
+    delete_parser.add_argument('timestamp', help='timestamp of lore to delete')
+
+    update_parser = subparsers.add_parser("update")
+    update_parser.add_argument('timestamp', help='timestamp of lore to update')
+    update_parser.add_argument('author', help='author of the lore')
+    update_parser.add_argument('lore', help='text of the lore')
+
     # Parse the args and call whatever function was selected
     args = main_parser.parse_args()
 
@@ -83,6 +92,10 @@ def main():
         random(pattern=args.pattern)
     elif args.command == "top":
         top(num=args.num)
+    elif args.command == "delete":
+        delete(args.timestamp)
+    elif args.command == "update":
+        update(args.timestamp, args.author, args.lore)
     else:
         main_parser.print_help()
         sys.exit(1)
@@ -101,7 +114,7 @@ def add(db, author, lore):
         l = Lore.create(time=now, author=author, lore=lore, rating=0)
         print(l)
     else:
-        print("Lore already exists...")
+        print("Lore already exists")
     db.commit()
 
 
@@ -143,7 +156,7 @@ def import_lore(old_lore):
             author = row[1]
             lore = row[2]
             try:
-                t = parser.parse(t_str)
+                t = datetime_parser.parse(t_str)
             except ValueError:
                 t = None
             Lore.create(time=t, author=author, lore=lore, rating=0)
@@ -171,6 +184,56 @@ def top(num=10):
             lore.author = "[blank]"
         print(lore.author.ljust(col_size), '\t', lore.count)
 
+
+# def _num_lores(timestamp):
+#     lore = Lore.select(Lore.time == timestamp)
+#     matches = lore.count()
+#     if matches == 0:
+#         raise RuntimeError("No lore with timestamp")
+#     elif matches > 1:
+#         raise RuntimeError("Multiple pieces of lore matched timestmap")
+#     else:
+#         return lore
+
+
+def delete(timestamp):
+    try:
+        t = datetime_parser.parse(timestamp)
+    except ValueError as err:
+        print("Invalid timestamp:", err)
+        sys.exit(1)
+    num = Lore.select().where(Lore.time == t).count()
+    if num == 0:
+        print("No lore with timestamp")
+        sys.exit(1)
+    if num > 1:
+        print("Multiple pieces of lore matched timestamp")
+        sys.exit(1)
+
+    l = Lore.get(Lore.time == t)
+    rows_deleted = l.delete_instance()
+    print("Deleted %d lores" % rows_deleted)
+
+
+def update(timestamp, author, lore):
+    try:
+        t = datetime_parser.parse(timestamp)
+    except ValueError as err:
+        print("Invalid timestamp:", err)
+        sys.exit(1)
+    num = Lore.select().where(Lore.time == t).count()
+    if num == 0:
+        print("No lore with timestamp")
+        sys.exit(1)
+    if num > 1:
+        print("Multiple pieces of lore matched timestamp")
+        sys.exit(1)
+
+    l = Lore.get(Lore.time == t)
+    l.author = author
+    l.lore = lore
+    l.save()
+    print("Lore updated")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This adds two commands: `update` and `delete`.

`update <timestamp> <author> <lore>` will replace an existing piece of lore with the new details (matched by timestamp).

`delete <timestamp>` will delete the piece of lore, matched by the timestamp.

Both commands will exit with an error if no lore matches, or more than one piece of lore matches (future work may be to do this by ID instead of timestamp, but we already have easy access to the timestamp).

Fixes #13 
