### PR TITLE
Add upvote/downvote and ratings support

### DIFF
--- a/loredb.py
+++ b/loredb.py
@@ -13,20 +13,36 @@ from dateutil import parser as datetime_parser
 import peewee
 
 
+def compute_rating(upvotes, downvotes):
+    return upvotes / (upvotes + downvotes)
+
+
 class BaseModel(peewee.Model):
     class Meta:
         database = peewee.SqliteDatabase(None)
 
 
 class Lore(BaseModel):
+    # Lore details
     time = peewee.DateTimeField(null=True, index=True)
     author = peewee.CharField(null=True, index=True)
     lore = peewee.CharField()
-    upvotes = peewee.IntegerField(null=False, default=4)
-    downvotes = peewee.IntegerField(null=False, default=10)
+
+    # Bayesian priors for voting
+    fake_upvotes = 4
+    fake_downvotes = 10
+
+    # Voting
+    upvotes = peewee.IntegerField(null=False, default=fake_upvotes)
+    downvotes = peewee.IntegerField(null=False, default=fake_downvotes)
+    rating = peewee.FloatField(null=False,
+                               default=compute_rating(fake_upvotes,
+                                                      fake_downvotes),
+                               index=True)
 
     def __str__(self):
-        return "[%s] [rating: %f] [%s]\n%s" % (self.time, compute_rating(self.upvotes, self.downvotes), self.author, self.lore)
+        return "[%s] [rating: %.3f] [%s]\n%s" % (
+            self.time, self.rating, self.author, self.lore)
 
 
 def main():
@@ -80,7 +96,12 @@ def main():
     upvote_parser.add_argument('timestamp', help='timestamp of lore to upvote')
 
     downvote_parser = subparsers.add_parser("downvote")
-    downvote_parser.add_argument('timestamp', help='timestamp of lore to downvote')
+    downvote_parser.add_argument(
+        'timestamp', help='timestamp of lore to downvote')
+
+    best_parser = subparsers.add_parser("best")
+    best_parser.add_argument('-n', '--num', help='number of lore to return',
+                             type=int, default=10)
 
     # Parse the args and call whatever function was selected
     args = main_parser.parse_args()
@@ -104,9 +125,11 @@ def main():
     elif args.command == "update":
         update(args.timestamp, args.author, args.lore)
     elif args.command == "upvote":
-        upvote(args.timestamp)
+        vote(args.timestamp, which='up')
     elif args.command == "downvote":
-        downvote(args.timestamp)
+        vote(args.timestamp, which='down')
+    elif args.command == "best":
+        best(num=args.num)
     else:
         main_parser.print_help()
         sys.exit(1)
@@ -122,7 +145,7 @@ def add(db, author, lore):
     num_matches = Lore.select().where(
         Lore.author == author and Lore.lore == lore).count()
     if num_matches == 0:
-        l = Lore.create(time=now, author=author, lore=lore, rating=0)
+        l = Lore.create(time=now, author=author, lore=lore)
         print(l)
     else:
         print("Lore already exists")
@@ -170,7 +193,7 @@ def import_lore(old_lore):
                 t = datetime_parser.parse(t_str)
             except ValueError:
                 t = None
-            Lore.create(time=t, author=author, lore=lore, rating=0)
+            Lore.create(time=t, author=author, lore=lore)
 
 
 def random(pattern=None):
@@ -194,6 +217,11 @@ def top(num=10):
         if lore.author == "":
             lore.author = "[blank]"
         print(lore.author.ljust(col_size), '\t', lore.count)
+
+
+def best(num=10):
+    for lore in Lore.select().order_by(Lore.rating.desc()).limit(num):
+        print(lore, '\n')
 
 
 def delete(timestamp):
@@ -249,7 +277,7 @@ def vote(timestamp, which='up'):
     if num > 1:
         print("Multiple pieces of lore matched timestamp")
         sys.exit(1)
-    
+
     l = Lore.get(Lore.time == t)
     if which == 'up':
         l.upvotes += 1
@@ -258,12 +286,10 @@ def vote(timestamp, which='up'):
     else:
         print("Invalid voting requested:", which)
         sys.exit(1)
+    # Update the lore rating
+    l.rating = compute_rating(l.upvotes, l.downvotes)
     l.save()
     print("Lore updated")
-
-
-def compute_rating(upvotes, downvotes):
-    return upvotes / (upvotes + downvotes)
 
 
 if __name__ == "__main__":

--- a/loredb.py
+++ b/loredb.py
@@ -22,10 +22,11 @@ class Lore(BaseModel):
     time = peewee.DateTimeField(null=True, index=True)
     author = peewee.CharField(null=True, index=True)
     lore = peewee.CharField()
-    rating = peewee.FloatField()
+    upvotes = peewee.IntegerField(null=False, default=4)
+    downvotes = peewee.IntegerField(null=False, default=10)
 
     def __str__(self):
-        return "[%s] [%s]\n%s" % (self.time, self.author, self.lore)
+        return "[%s] [+1 %d / -1 %d] [%s]\n%s" % (self.time, self.upvotes, self.downvotes, self.author, self.lore)
 
 
 def main():

--- a/migrations/add_voting.py
+++ b/migrations/add_voting.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import peewee
+from playhouse.migrate import *
+
+db = SqliteDatabase('lore.db')
+migrator = SqliteMigrator(db)
+
+upvote_field = IntegerField(null=False, default=4)
+downvote_field = IntegerField(null=False, default=10)
+
+migrate(
+    migrator.add_column(table, 'upvotes', upvote_field)
+    migrator.add_column(table, 'downvotes', downvote_field)
+    migrator.drop_column(table, 'rating')
+)

--- a/migrations/add_voting.py
+++ b/migrations/add_voting.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 
 import peewee
-from playhouse.migrate import *
+from playhouse.migrate import SqliteMigrator, migrate
+from loredb import BaseModel, Lore, compute_rating
 
-db = SqliteDatabase('lore.db')
+lore_file = 'lore.db'
+db = BaseModel._meta.database
+db.init(lore_file)
+
+table = 'Lore'
 migrator = SqliteMigrator(db)
 
-upvote_field = IntegerField(null=False, default=4)
-downvote_field = IntegerField(null=False, default=10)
+upvote_field = peewee.IntegerField(null=False, default=4)
+downvote_field = peewee.IntegerField(null=False, default=10)
 
 migrate(
-    migrator.add_column(table, 'upvotes', upvote_field)
+    migrator.add_column(table, 'upvotes', upvote_field),
     migrator.add_column(table, 'downvotes', downvote_field)
-    migrator.drop_column(table, 'rating')
 )
+
+# Iterate through each row and update their rating
+for lore in Lore.select():
+    lore.rating = compute_rating(lore.upvotes, lore.downvotes)
+    lore.save()

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,73 @@
+from unittest import TestCase, main
+from playhouse.test_utils import test_database
+from peewee import SqliteDatabase
+from datetime import datetime, timedelta
+
+from loredb import (BaseModel, Lore, compute_rating, vote)
+
+test_db = SqliteDatabase(':memory:')
+test_time = datetime.now()
+
+
+class TestFunctions(TestCase):
+    def test_compute_rating(self):
+        upvotes = 5
+        downvotes = 15
+        # rating = 5 / 20
+        self.assertEqual(0.25, compute_rating(upvotes, downvotes))
+
+    def test_compute_rating_low(self):
+        upvotes = 0
+        downvotes = 10
+        # rating = 0
+        self.assertEqual(0.0, compute_rating(upvotes, downvotes))
+
+    def test_compute_rating_high(self):
+        upvotes = 100
+        downvotes = 0
+        self.assertEqual(1.0, compute_rating(upvotes, downvotes))
+
+    def test_compute_rating_negative(self):
+        # Vote commands only allow incrementing the integers, but nothing
+        # in the database schema prevents them from going negative.
+        upvotes = -1
+        downvotes = 11
+        self.assertEqual(-0.1, compute_rating(upvotes, downvotes))
+
+
+class TestLoreVoting(TestCase):
+    # Bayesian priors
+    # fake_upvotes = 4
+    # fake_downvotes = 10
+
+    def create_test_data(self):
+        # Create some lore
+        for i in range(10):
+            t = test_time + timedelta(i*100)
+            lore = "lore #%d" % i
+            Lore.create(time=t, author=str(i), lore=lore)
+
+    def test_initial_rating(self):
+        # Setup
+        with test_database(test_db, (BaseModel, Lore)):
+            self.create_test_data()
+            self.assertEqual(Lore.get(time=test_time).lore, "lore #0")
+            self.assertEqual(Lore.get(time=test_time).rating, 4 / 14)
+
+    def test_upvote(self):
+        with test_database(test_db, (BaseModel, Lore)):
+            self.create_test_data()
+            vote(str(test_time), which='up')
+            self.assertEqual(Lore.get(time=test_time).upvotes, 5)
+            self.assertEqual(Lore.get(time=test_time).rating, 5 / 15)
+
+    def test_downvote(self):
+        with test_database(test_db, (BaseModel, Lore)):
+            self.create_test_data()
+            vote(str(test_time), which='down')
+            self.assertEqual(Lore.get(time=test_time).downvotes, 11)
+            self.assertEqual(Lore.get(time=test_time).rating, 4 / 15)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds:
- Commands to `upvote` and `downvote` lore (by timestamp)
  - A composite rating (0.0-1.0) is computed using a Bayesian prior (a base number of "fake" upvotes and downvotes, see https://julesjacobs.github.io/2015/08/17/bayesian-scoring-of-ratings.html for more details of the approach).
- A new command to return the `best` lore (by rating) is also added.
- A migration to add the necessary database columns for upvotes and downvotes is added to `migrations/`.
