### PR TITLE
Add support for removing tags

### DIFF
--- a/loredb.py
+++ b/loredb.py
@@ -142,6 +142,12 @@ def main():
                                 type=int, default=10)
     get_tag_parser.set_defaults(func=_get_tag)
 
+    remove_tag_parser = subparsers.add_parser('delete-tag')
+    remove_tag_parser.add_argument('id', type=int,
+                                   help='id of lore to remove tag from')
+    remove_tag_parser.add_argument('tag', help='tag to remove')
+    remove_tag_parser.set_defaults(func=_remove_tag)
+
     # Parse the args and call whatever function was selected
     args = main_parser.parse_args()
     if args.command is None:
@@ -382,6 +388,20 @@ def get_tag(tag, num=10):
         sys.exit(1)
     for lore in t.lores.limit(num):
         print(lore, '\n')
+
+
+def _remove_tag(args):
+    remove_tag(args.id, args.tag)
+
+
+def remove_tag(lore_id, tag):
+    try:
+        l = Lore.get(Lore.id == lore_id)
+        t = Tag.get(Tag.name == tag)
+    except peewee.DoesNotExist as err:
+        print("Invalid id or tag:", err)
+        sys.exit(1)
+    l.tags.remove(t)
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,7 @@ from peewee import SqliteDatabase
 from datetime import datetime, timedelta
 
 from loredb import (BaseModel, Tag, Lore, LoreTag, compute_rating, upvote,
-                    downvote, add, get_top_lore, add_tags)
+                    downvote, add, get_top_lore, add_tags, remove_tag)
 
 test_db = SqliteDatabase(':memory:')
 test_time = datetime.now()
@@ -138,6 +138,14 @@ class TestTags(TestCase):
             add_tags(1, ["lasagna"])
             l = Lore.get(author="bob", lore="lore")
             self.assertIn("lasagna", [str(t) for t in l.tags])
+
+    def test_remove_tag(self):
+        with test_database(test_db, (BaseModel, Lore, Tag, LoreTag)):
+            add("bob", ["lore"])
+            add_tags(1, ["lasagna"])
+            remove_tag(1, "lasagna")
+            l = Lore.get(author="bob", lore="lore")
+            self.assertNotIn("lasagna", [str(t) for t in l.tags])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Forgot to include this in #38. This adds a `delete-lore` command to remove individual tags from specified lore.

This should complete the base functionality for #33.